### PR TITLE
Use FORMAT(%T) instead of TO_JSON_STRING to check data type

### DIFF
--- a/bqtestmagic.py
+++ b/bqtestmagic.py
@@ -35,14 +35,14 @@ class BigQueryTest:
                 *
               FROM (
                 SELECT
-                  TO_JSON_STRING(actual) AS json_string,
+                  FORMAT("%T", actual) AS json_string,
                   COUNT(*) AS count
                 FROM (\n{textwrap.indent(left.rstrip(), "                  ")} ) AS actual
                 GROUP BY
                   json_string) AS actual
               FULL JOIN (
                 SELECT
-                  TO_JSON_STRING(expected) AS json_string,
+                  FORMAT("%T", expected) AS json_string,
                   COUNT(*) AS count
                 FROM (\n{textwrap.indent(right.rstrip(), "                  ")} ) AS expected
                 GROUP BY

--- a/test_bqtestmagic.py
+++ b/test_bqtestmagic.py
@@ -286,8 +286,8 @@ class TestBigQueryTest:
     @pytest.mark.parametrize(
         ("left", "right", "expected"),
         [
-            ("SELECT 1 a", "SELECT 0 + 1 a", True),
-            ("SELECT 1 a", "SELECT 1 + 1 a", False),
+            ('SELECT NUMERIC "1" a', 'SELECT NUMERIC "1" * 1 a', True),
+            ('SELECT NUMERIC "1" a', 'SELECT "1" a', False),
         ],
     )
     def test_query_to_check_that_two_query_results_match(


### PR DESCRIPTION
Using TO_JSON_STRING may cause multiple data types to be converted to the same string.
FORMAT(%T) includes type information in the string, so we can check for type matches.